### PR TITLE
Allow passing in initializer args (fixes compatibility with rails)

### DIFF
--- a/lib/eventable/eventable.rb
+++ b/lib/eventable/eventable.rb
@@ -30,7 +30,7 @@ module Eventable
     base.extend(EventableEventMethods)
   end
 
-  def initialize
+  def initialize *args
     super
     @eventable_mutex = Mutex.new
   end


### PR DESCRIPTION
When using eventable with activerecord or any framework that requires the ability to pass in initializer params the app errors out because it is not possible to pass in any arguments when initializing model due to the no args constructor. This amounts to not being able to use eventable with rails and other frameworks.

All I did was add a *args to the initializer declaration and it all started working. 
